### PR TITLE
Removed Jacoco as it's causing build issues on RN 0.62

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,6 @@ def androidExclusion = [
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
-apply plugin: 'jacoco'
 
 buildscript {
     // The Android Gradle plugin is only required when opening the android folder stand-alone.
@@ -185,27 +184,6 @@ afterEvaluate { project ->
             repository url: "file://${projectDir}/../android/maven"
             configureReactNativePom pom
         }
-    }
-
-    task codeCoverageReport(type: JacocoReport, dependsOn: 'testDebugUnitTest') {
-        group = "Reporting"
-        description = "Generate Jacoco coverage reports after running tests."
-        reports {
-            xml.enabled = true
-            html.enabled = true
-            csv.enabled = true
-        }
-        classDirectories = fileTree(
-                dir: 'build/intermediates/javac/debug/compileDebugJavaWithJavac/classes/com/onfido/reactnative/sdk',
-                excludes: androidExclusion
-        )
-        sourceDirectories = files('src/main/java/com/onfido/reactnative/sdk')
-        executionData = files('build/jacoco/testDebugUnitTest.exec')
-    }
-
-    task getCoverage(type: Exec, dependsOn: 'codeCoverageReport') {
-        group = "Reporting"
-        commandLine "open", "$buildDir/reports/jacoco/codeCoverageReport/html/index.html"
     }
 }
 


### PR DESCRIPTION
Hey guys,

as we tried to add your SDK to our app we've noticed that it won't build on RN 0.62.2. It shows the following error when running `react-native-run-android`:
> * What went wrong:
> A problem occurred configuring project ':onfido_react-native-sdk'.
> > Cannot set the value of read-only property 'classDirectories' for task ':onfido_react-native-sdk:codeCoverageReport' of type org.gradle.testing.jacoco.tasks.JacocoReport.

Here is a repro project: 
[onfidiotest.zip](https://github.com/onfido/react-native-sdk/files/4668032/onfidiotest.zip)
I've just created a new RN app with RN 0.62.2 and installed this SDK.

So I've decided to strip jacoco from the lib. This is rather a hotfix than an actual solution...