### PR TITLE
Allow React versions 17.0.X.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "react": ">=16.8.1 <17.0.x",
+    "react": ">=16.8.1 <=17.0.x",
     "react-native": ">=0.60.0-rc.0 <1.0.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi! We're trying to upgrade our onfido library in order to be compatible with Swift 5.5 and use XCode 13, but we're having issues with the NPM resolution of the peer dependencies.

It was introduced [1] a version check for React version to be less than 17.0.X while the original intent seems to be less or equal to, based on the changelog files.

The error we get are while trying to install @onfido/react-native-sdk@2.2.0:

```npm ERR! While resolving: projectName@1.7.0
npm ERR! Found: react@17.0.2

npm ERR! Could not resolve dependency:
npm ERR! peer react@">=16.8.1 <17.0.x" from @onfido/react-native-sdk@2.2.0
npm ERR! node_modules/@onfido/react-native-sdk
npm ERR!   @onfido/react-native-sdk@"^2.0.0" from the root project
```

Thank you and let me know if you need anything from me to address this PR.

[1] https://github.com/onfido/react-native-sdk/commit/c99c7f3676d116afa992a70530fd474480f69baf