### PR TITLE
Add the ability to listen for Onfido SDK user analytics events.

### DIFF
--- a/ios/OnfidoSdk-Bridging-Header.h
+++ b/ios/OnfidoSdk-Bridging-Header.h
@@ -3,3 +3,4 @@
 //
 
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>

--- a/ios/OnfidoSdk.m
+++ b/ios/OnfidoSdk.m
@@ -1,7 +1,8 @@
 #import <Foundation/Foundation.h>
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
-@interface RCT_EXTERN_MODULE(OnfidoSdk, NSObject)
+@interface RCT_EXTERN_MODULE(OnfidoSdk, RCTEventEmitter)
 
 RCT_EXTERN_METHOD(
     start:(NSDictionary *)config

--- a/js/Onfido.js
+++ b/js/Onfido.js
@@ -1,4 +1,4 @@
-import { NativeModules, Platform } from 'react-native';
+import { NativeModules, NativeEventEmitter, Platform } from 'react-native';
 import { OnfidoDocumentType, OnfidoCaptureType, OnfidoCountryCode, OnfidoAlpha2CountryCode } from "./config_constants";
 
 const { OnfidoSdk } = NativeModules;
@@ -59,6 +59,10 @@ const Onfido = {
       console.log(error);
       throw error;
     });
+  },
+  addEventListener(callback) {
+    const eventEmitter = new NativeEventEmitter(OnfidoSdk);
+    return eventEmitter.addListener("Onfido", callback)
   }
 };
 


### PR DESCRIPTION
This change exposes the user analytics data from the Android and iOS SDKs as described [here](https://documentation.onfido.com/sdk/android/#user-analytics) and [here](https://documentation.onfido.com/sdk/ios/#user-analytics).