### PR TITLE
Fixing TypeScript error

### DIFF
--- a/js/config_constants.ts
+++ b/js/config_constants.ts
@@ -28,6 +28,7 @@ export type OnfidoResult = {
 
 export type OnfidoConfig = {
   sdkToken: string;
+  workflowRunId?: string;
   flowSteps: OnfidoFlowSteps;
   hideLogo?: boolean;
   logoCoBrand?: boolean


### PR DESCRIPTION
When using the npm, there's a missing typescript definition:
```
node_modules/@onfido/react-native-sdk/js/Onfido.ts(29,16): error TS2339: Property 'workflowRunId' does not exist on type 'OnfidoConfig'.
```

This small change fixes that error.