### PR TITLE
[Android] Fix Android build failures with RN 0.72

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -135,9 +135,9 @@ afterEvaluate { project ->
         group = "Reporting"
         description = "Generate Jacoco coverage reports after running tests."
         reports {
-            xml.enabled = true
-            html.enabled = true
-            csv.enabled = true
+            xml.required = true
+            html.required = true
+            csv.required = true
         }
         classDirectories.setFrom(fileTree(
                 dir: 'build/intermediates/javac/debug/compileDebugJavaWithJavac/classes/com/onfido/reactnative/sdk',


### PR DESCRIPTION
# Description

RN projects starting from 0.72 are going to use Gradle 8.x to build the Android app. This library is using a `enabled` flag in `build.gradle` that is already deprecated in Gradle 7.x and was removed in Gradle 8.x. This PR aims to solve this by using the new flag `required`.

# Test Plan

1. Setup a RN project with the 0.72 release candidate.
2. Add `@onfido/react-native-sdk` library to project.
3. Run the Android build.
4. Verify if the build succeeds.
5. Repeat the steps above for a previous RN release, e.g 0.71, 0.70.