### PR TITLE
Add `publishing` block in `build.gradle`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,6 +84,13 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 }
 
 repositories {


### PR DESCRIPTION
https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes
> AGP 8.0 creates no SoftwareComponent by default. Instead AGP creates SoftwareComponents only for variants that are configured to be published using the publishing DSL.

This causes the library not to build when used alongside React Native 0.73. Adding the `publishing` block, causes AGP to create the `release` component again, fixing the build.

See https://developer.android.com/build/publish-library/configure-pub-variants and https://developer.android.com/reference/tools/gradle-api/7.1/com/android/build/api/dsl/PublishingOptions