### PR TITLE
Fix for "Could not get unknown property 'release' for SoftwareComponent

### DIFF
--- a/android/publish.gradle
+++ b/android/publish.gradle
@@ -14,7 +14,7 @@ afterEvaluate {
                 groupId = 'com.onfido.reactnative.sdk'
                 version = packageJson.version
 
-                from components.release
+                from components.findByName('release')
 
                 artifact sourceJar
 


### PR DESCRIPTION
Fix for "Could not get unknown property 'release' for SoftwareComponent container of type org.gradle.api.internal.component.DefaultSoftwareComponentContainer" exception buinding with Android gradle plugin: 8.1.1 and Gradle: 8