### PR TITLE
Fix for required flowSteps if workflowRunId exists.

### DIFF
--- a/js/config_constants.ts
+++ b/js/config_constants.ts
@@ -30,8 +30,6 @@ export type OnfidoResult = {
 
 export type OnfidoConfig = {
   sdkToken: string;
-  workflowRunId?: string;
-  flowSteps: OnfidoFlowSteps;
   hideLogo?: boolean;
   logoCoBrand?: boolean;
   disableNFC?: boolean;
@@ -40,7 +38,10 @@ export type OnfidoConfig = {
     ios_strings_file_name?: string;
   };
   theme: OnfidoTheme;
-};
+} & (
+  | { workflowRunId: undefined; flowSteps: OnfidoFlowSteps }
+  | { workflowRunId: string; flowSteps?: OnfidoFlowSteps }
+);
 
 export interface OnfidoError extends Error {
   code?: string;


### PR DESCRIPTION
# Description

If workflowRunId exists (and is not undefined), flowSteps will be completely ignored. 
In the workflow documentation, the config is passed without flowSteps but in the current type, it's always required.

Link to documentation: https://developers.onfido.com/guide/studio-react-native-sdk-integration#start-here

### Fix and what has changed.

Use conditional typing.

```ts
export type OnfidoConfig = {
  sdkToken: string;
  hideLogo?: boolean;
  logoCoBrand?: boolean;
  disableNFC?: boolean;
  disableMobileSdkAnalytics?: boolean;
  localisation?: {
    ios_strings_file_name?: string;
  };
  theme: OnfidoTheme;
} & (
  | { workflowRunId: undefined; flowSteps: OnfidoFlowSteps }
  | { workflowRunId: string; flowSteps?: OnfidoFlowSteps } // Note! flowSteps is now optional because it allows the configuration to be used as a fallback incase workflowRunId is undefined by mistake.
);
``